### PR TITLE
Add invalid dimension test

### DIFF
--- a/tests/test_kymograph.py
+++ b/tests/test_kymograph.py
@@ -42,3 +42,10 @@ def test_make_kymograph_output():
     
     # Check that the kymograph values are within the expected range of the original image (0, 1)
     assert kymo.min() >= 0 and kymo.max() <= 1
+
+
+def test_make_kymograph_invalid_dims():
+    image = np.random.random((256, 256))
+    centroids = np.array([[0, 0]])
+    with pytest.raises(ValueError):
+        make_kymograph(image, centroids)


### PR DESCRIPTION
## Summary
- add a test for invalid image dimensions in `make_kymograph`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError for numpy)*

------
https://chatgpt.com/codex/tasks/task_e_686fe622f48083319d965240c147f5bf