### PR TITLE
Fix centroid order to time-y-x

### DIFF
--- a/kymograph_py/kymograph_py.py
+++ b/kymograph_py/kymograph_py.py
@@ -420,7 +420,7 @@ def make_kymograph(image: np.ndarray, centroids, stabilize = False, width=5, hei
         order [T, Y, X] where T is time, Y is the Y-axis of the images, and X is the X-axis of the images.
 
     centroids: ndarray
-        An array of shape (N, 2) where N is the number of time points. Each entry contains the (x, y)
+        An array of shape (N, 2) where N is the number of time points. Each entry contains the (y, x)
         coordinates of the centroid at that time point.
 
     width: int, optional
@@ -454,7 +454,9 @@ def make_kymograph(image: np.ndarray, centroids, stabilize = False, width=5, hei
     # Initialize the kymograph list to hold slices from each time point
     kymograph_slices = []
 
-    # Process each time point based on the centroid coordinates
+    # Process each time point based on the centroid coordinates. The centroids
+    # array is expected to contain coordinates in ``(y, x)`` order. This matches
+    # the [T, Y, X] axis convention of the input image.
     for t, (y, x) in enumerate(centroids):
         # Calculate the bounding box around the centroid
         x0 = int(max(x - width // 2, 0))

--- a/tests/test_centroid_order.py
+++ b/tests/test_centroid_order.py
@@ -1,0 +1,17 @@
+import numpy as np
+from kymograph_py import make_kymograph
+
+
+def test_centroid_coordinate_order():
+    # Create an image stack where pixel values depend only on the x coordinate
+    image = np.arange(3, dtype=float)[None, None, :].repeat(3, axis=1)
+    image = image.repeat(2, axis=0)  # Shape (2, 3, 3)
+
+    # Centroid is given in (y, x) order
+    centroids = np.tile(np.array([1, 2]), (image.shape[0], 1))
+
+    kymo = make_kymograph(image, centroids, width=1, height=1)
+
+    assert kymo.shape == (1, image.shape[0])
+    expected = np.full((1, image.shape[0]), 2, dtype=float)
+    assert np.array_equal(kymo, expected)

--- a/tests/test_kymograph.py
+++ b/tests/test_kymograph.py
@@ -10,11 +10,12 @@ def test_make_kymograph_output():
     image = np.random.random((60, 256, 256))
     
     # Compute centroids as in your demo:
-    # x coordinate: int(image.shape[1] // 2 * 1.2)
-    # y coordinate: int(image.shape[2] // 2 * 0.85)
-    centroid_x = int(image.shape[1] // 2 * 1.2)
-    centroid_y = int(image.shape[2] // 2 * 0.85)
-    centroids = np.tile(np.array([centroid_x, centroid_y]), (image.shape[0], 1))
+    # y coordinate: int(image.shape[1] // 2 * 1.2)
+    # x coordinate: int(image.shape[2] // 2 * 0.85)
+    centroid_y = int(image.shape[1] // 2 * 1.2)
+    centroid_x = int(image.shape[2] // 2 * 0.85)
+    # Centroids are stored in (y, x) order
+    centroids = np.tile(np.array([centroid_y, centroid_x]), (image.shape[0], 1))
     
     # Call make_kymograph with specified parameters
     kymo = make_kymograph(image, centroids, width=10, height=100, skip_step=2)


### PR DESCRIPTION
## Summary
- revert earlier change and ensure centroids are specified as `(y, x)`
- update docs to mention `(y, x)` order
- adapt unit tests to match the expected centroid orientation

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*


------
https://chatgpt.com/codex/tasks/task_e_686fe3bc182c8331825bc0a8388bf88c