### PR TITLE
Reduce package dependencies

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,7 +6,7 @@
 
 ## Dependencies
 - Development requirements are listed in `requirements-dev.txt` which installs the package in editable mode and includes `numpy` and `pytest`.
-- The package itself depends on `numpy`, `pandas`, `tqdm`, `matplotlib`, `scikit-image`, and `scipy` as declared in `setup.py`.
+- The package itself depends on `numpy`, `tqdm`, and `scipy` as declared in `setup.py`.
 
 ## Python Versions
 - GitHub Actions tests the code on Python 3.9, 3.11, 3.12 and 3.13.

--- a/setup.py
+++ b/setup.py
@@ -17,10 +17,7 @@ setup(
     packages=find_packages(), # Automatically find packages
     install_requires=[        # Dependencies
         'numpy',
-        'pandas',
         'tqdm',
-        'matplotlib',
-        'scikit-image',
         'scipy',
     ],
     classifiers=[             # Optional metadata


### PR DESCRIPTION
## Summary
- drop pandas, scikit-image and matplotlib from install requirements
- implement a lightweight `phase_cross_correlation` using NumPy
- adjust drift table handling so it uses lists of dicts instead of pandas

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6871200da1b08331bb5d759fb982d28f